### PR TITLE
🐛 Dory Website No Styling

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,7 +21,7 @@
 title: SSW Dory
 description: >- # this means to ignore newlines until "baseurl:"
   SSW's intelligent workflow solution designed to streamline collaboration and reduce roadblocks in your daily operations.
-baseurl: "/SSW.Dory/docs" # the subpath of your site, e.g. /blog
+baseurl: "/SSW.Dory" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Change baseurl from /SSW.Dory/docs to /SSW.Dory.\
@JackDevAU looks like your initial review to use /SSW.Dory is correct as /SSW.Dory/docs doesn't work. 

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->
<img width="750" alt="image" src="https://github.com/SSWConsulting/SSW.Dory/assets/41951199/a3180871-5a88-4737-8c67-cc5100c6f4da">\
Figure: Incorrect path for /SSW.Dory/docs

<img width="782" alt="image" src="https://github.com/SSWConsulting/SSW.Dory/assets/41951199/749e9305-ef2c-4e16-b4d6-68fe3a33ec5e">\
Figure: Correct path with /SSW.Dory

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
