### PR TITLE
✨ Add CTA to SSW Dory Website

### DIFF
--- a/content/src/app/globals.css
+++ b/content/src/app/globals.css
@@ -8,12 +8,14 @@
   --background-end-rgb: 255, 255, 255;
 }
 
-*, ::before, ::after {
+*,
+::before,
+::after {
   border-style: none;
 }
- 
+
 html {
-  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 body {
@@ -39,21 +41,29 @@ body {
   background-color: hsla(0, 0%, 40%, 0.1);
 }
 
+.bg-ssw-red,
+.bg-sswRed {
+  --tw-bg-opacity: 1;
+  background-color: rgb(204 65 65 / var(--tw-bg-opacity));
+}
+
 .text-ssw-red {
   --tw-text-opacity: 1;
   color: rgb(204 65 65 / var(--tw-text-opacity));
 }
 
-a.footer-link,a.footer-link:visited  {
+a.footer-link,
+a.footer-link:visited {
   @apply text-white;
-  line-height: .75rem;
+  line-height: 0.75rem;
   transition: all 0.3s ease-in-out;
   &:hover {
     @apply text-ssw-red;
   }
 }
 
-a.footer-greybar-link, a.footer-greybar-link:hover {
+a.footer-greybar-link,
+a.footer-greybar-link:hover {
   text-decoration: underline;
 }
 

--- a/content/src/app/page.tsx
+++ b/content/src/app/page.tsx
@@ -72,6 +72,18 @@ export default function Home() {
           description="A low-code solution for easy set-up and configuration."
           imgURL="/dory-architecture-diagram.webp"
         />
+
+        <section className="text-gray-700 body-font">
+          <div className="container mx-auto mb-32 md:mb-0 flex px-5 py-10 items-center justify-center flex-col">
+            <h2 className="title-font leading-tight sm:text-4xl text-3xl mb-4 font-medium text-ssw-red">
+              Sold?
+            </h2>
+            <h3 className="leading-relaxed max-w-xl">
+              Call us on <strong>+61 2 9953 3000</strong> to discuss how we can
+              set this up for you
+            </h3>
+          </div>
+        </section>
       </div>
       <Footer />
     </main>

--- a/content/src/app/page.tsx
+++ b/content/src/app/page.tsx
@@ -75,13 +75,15 @@ export default function Home() {
 
         <section className="text-gray-700 body-font">
           <div className="container mx-auto mb-32 md:mb-0 flex px-5 py-10 items-center justify-center flex-col">
-            <h2 className="title-font leading-tight sm:text-4xl text-3xl mb-4 font-medium text-ssw-red">
+            <h2 className="title-font leading-tight sm:text-4xl text-3xl mb-4 font-medium text-gray-900">
               Sold?
             </h2>
-            <h3 className="leading-relaxed max-w-xl">
-              Call us on <strong>+61 2 9953 3000</strong> to discuss how we can
-              set this up for you
-            </h3>
+            <a href="https://www.ssw.com.au/company/contact-us" target="_blank">
+              <button className="overflow-hidden border-none py-3 px-10 text-[1.6rem] bg-sswRed text-white rounded">
+                Contact Us
+              </button>
+            </a>
+            <h3 className="leading-relaxed max-w-xs mt-4 text-center">Contact an Account Manager to discuss how we can set this up for you.</h3>
           </div>
         </section>
       </div>


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Fixes #77 

Currently don't have a way for others to contact us if they are interested in SSW Dory. This PR adds in a CTA that links to the SSW website [contact-us page](https://www.ssw.com.au/company/contact-us).

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->
<img width="1393" alt="image" src="https://github.com/SSWConsulting/SSW.Dory/assets/41951199/de29b314-8397-4390-b9ce-b68e421f29bf">\
**Figure: SSW Dory website CTA**

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
